### PR TITLE
loginSuccess event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### CHANGELOG
 
+## [v0.16.0]
+
+### Updated
+
+- LucraClient constructor now accepts `locationId` to set the location without having to navigate to `home`
+- LucraClient constructor has deprecated `useTestUsers` as its now no longer needed to log in with test users
+- Calling `.open` on the LucraClient when it's already open will perform a `redirect` instead of incorrectly adding another iframe
+- New `loginSuccess` callback that receives the user info. Wait for this callback to fire before sending any messages to LucraClient
+
 ## [v0.15.1]
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const lucraClient = new LucraClient({
   onMessage: {
     // callback functions for the messages sent to the SDK from Lucra, documented below
   },
-  useTestUsers: true | false // optional property to use test users. Not recommended for production.
+  locationId?: "<locationId>" // set the locationId without having to navigate to `home` with the `locationId`
 })
 ```
 
@@ -87,13 +87,14 @@ lucraClient.redirect()
   .deposit()
   .withdraw()
   .createMatchup(gameId?: string)
-  .matchupDetails(matchupId: string, teamInviteId?: string)
+  .matchupDetails(matchupId: string)
   .tournamentDetails(matchupId: string)
   .deepLink(url: string)
 ```
 
 ### Messages from LucraClient
 
+`loginSuccess` - the user has logged into Lucra
 `userInfo` - whenever an update happens to the user, the callback to this function will receive the newest version of that user
 `matchupCreated` - the user successfully created a matchup, and contains the id of that matchup
 `matchupStarted` - the matchup owner started the matchup, and contains the id of that matchup

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { type LucraClientSendMessage, type LucraConvertToCreditBody, type LucraDeepLinkBody, type LucraMatchupAcceptedBody, type LucraMatchupCanceledBody, type LucraMatchupCreatedBody, type LucraNavigationEventBody, type LucraTournamentJoinedBody, type LucraUserInfoBody, type StateCode, type StateFull, type LucraClientConstructor, type LucraClaimRewardBody, type LucraMatchupStartedBody } from "./types/types.js";
+import { type LucraClientSendMessage, type LucraConvertToCreditBody, type LucraDeepLinkBody, type LucraMatchupAcceptedBody, type LucraMatchupCanceledBody, type LucraMatchupCreatedBody, type LucraNavigationEventBody, type LucraTournamentJoinedBody, type LucraUserInfoBody, type StateCode, type StateFull, type LucraClientConstructor, type LucraClaimRewardBody, type LucraMatchupStartedBody, type LucraLoginSuccessBody } from "./types/types.js";
 export declare const LucraClientIframeId = "__lucrasports__";
 export declare const States: {
     state: StateFull;
@@ -45,8 +45,8 @@ export declare class LucraClient {
     private env;
     private urlOrigin;
     private url;
-    private useTestUsers;
     private messages;
+    private locationId;
     private onMessage;
     private controller;
     private iframeParentElement?;
@@ -59,7 +59,8 @@ export declare class LucraClient {
      * @param env sandbox | production
      * @param onMessage Message Handler for messages from LucraClient
      */
-    constructor({ tenantId, env, onMessage, useTestUsers, }: LucraClientConstructor);
+    constructor({ tenantId, env, onMessage, locationId, }: LucraClientConstructor);
+    set loginSuccessHandler(handlerFn: (data: LucraLoginSuccessBody) => void);
     set deepLinkHandler(handlerFn: (data: LucraDeepLinkBody) => void);
     set userInfoHandler(handlerFn: (data: LucraUserInfoBody) => void);
     set matchupCreatedHandler(handlerFn: (data: LucraMatchupCreatedBody) => void);

--- a/dist/types/types.d.ts
+++ b/dist/types/types.d.ts
@@ -9,7 +9,8 @@ export declare enum LucraClientMessageType {
     convertToCredit = "convertToCredit",
     deepLink = "deepLink",
     navigationEvent = "navigationEvent",
-    claimReward = "claimReward"
+    claimReward = "claimReward",
+    loginSuccess = "loginSuccess"
 }
 export declare enum MessageTypeToLucraClient {
     clientUserInfo = "clientUserInfo",
@@ -69,15 +70,19 @@ export type LucraDeepLinkBody = {
 };
 export type LucraNavigationEventBody = {
     url: string;
+    page?: LucraPage;
 };
 export type LucraClaimRewardBody = {
     reward: LucraReward;
 };
+export type LucraLoginSuccessBody = SDKLucraUser;
 export type LucraClientConstructor = {
     tenantId: string;
     env: LucraEnvironment;
     onMessage: LucraClientOnMessage;
+    /** @deprecated This is no longer utilized and will be removed in the next version */
     useTestUsers?: boolean;
+    locationId?: string;
 };
 export type LucraClientOnMessage = {
     userInfo: (data: LucraUserInfoBody) => void;
@@ -90,6 +95,7 @@ export type LucraClientOnMessage = {
     deepLink: (data: LucraDeepLinkBody) => void;
     navigationEvent: (data: LucraNavigationEventBody) => void;
     claimReward: (data: LucraClaimRewardBody) => void;
+    loginSuccess: (data: LucraLoginSuccessBody) => void;
 };
 export type LucraClientSendMessage = {
     userUpdated: (data: SDKClientUser) => void;
@@ -103,6 +109,7 @@ export type LucraClientMessage = (body: {
     type: LucraClientMessageType;
     data: any;
 }) => void;
+export type LucraPage = "add-funds" | "create-matchup" | "home" | "id-scan-complete" | "kyc" | "logout" | "matchup-details" | "profile" | "search" | "tournament-details" | "transactions" | "withdraw-funds";
 export type StateFull = "Alaska" | "Alabama" | "Arkansas" | "Arizona" | "California" | "Colorado" | "Connecticut" | "District of Columbia" | "Delaware" | "Florida" | "Georgia" | "Hawaii" | "Iowa" | "Idaho" | "Illinois" | "Indiana" | "Kansas" | "Kentucky" | "Louisiana" | "Massachusetts" | "Maryland" | "Maine" | "Michigan" | "Minnesota" | "Missouri" | "Mississippi" | "Montana" | "North Carolina" | "North Dakota" | "Nebraska" | "New Hampshire" | "New Jersey" | "New Mexico" | "Nevada" | "New York" | "Ohio" | "Oklahoma" | "Oregon" | "Pennsylvania" | "Rhode Island" | "South Carolina" | "South Dakota" | "Tennessee" | "Texas" | "Utah" | "Virginia" | "Vermont" | "Washington" | "Wisconsin" | "West Virginia" | "Wyoming";
 export type StateCode = "AK" | "AL" | "AR" | "AZ" | "CA" | "CO" | "CT" | "DC" | "DE" | "FL" | "GA" | "HI" | "IA" | "ID" | "IL" | "IN" | "KS" | "KY" | "LA" | "MA" | "MD" | "ME" | "MI" | "MN" | "MO" | "MS" | "MT" | "NC" | "ND" | "NE" | "NH" | "NJ" | "NM" | "NV" | "NY" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VA" | "VT" | "WA" | "WI" | "WV" | "WY";
 declare enum account_status_types_enum {

--- a/dist/types/types.js
+++ b/dist/types/types.js
@@ -10,6 +10,7 @@ export var LucraClientMessageType;
     LucraClientMessageType["deepLink"] = "deepLink";
     LucraClientMessageType["navigationEvent"] = "navigationEvent";
     LucraClientMessageType["claimReward"] = "claimReward";
+    LucraClientMessageType["loginSuccess"] = "loginSuccess";
 })(LucraClientMessageType || (LucraClientMessageType = {}));
 export var MessageTypeToLucraClient;
 (function (MessageTypeToLucraClient) {

--- a/types/types.ts
+++ b/types/types.ts
@@ -17,6 +17,7 @@ export enum LucraClientMessageType {
   deepLink = "deepLink",
   navigationEvent = "navigationEvent",
   claimReward = "claimReward",
+  loginSuccess = "loginSuccess",
 }
 
 export enum MessageTypeToLucraClient {
@@ -65,14 +66,17 @@ export type LucraMatchupAcceptedBody = { matchupId: string };
 export type LucraTournamentJoinedBody = { matchupId: string };
 export type LucraConvertToCreditBody = { amount: number };
 export type LucraDeepLinkBody = { url: string };
-export type LucraNavigationEventBody = { url: string };
+export type LucraNavigationEventBody = { url: string; page?: LucraPage };
 export type LucraClaimRewardBody = { reward: LucraReward };
+export type LucraLoginSuccessBody = SDKLucraUser;
 
 export type LucraClientConstructor = {
   tenantId: string;
   env: LucraEnvironment;
   onMessage: LucraClientOnMessage;
+  /** @deprecated This is no longer utilized and will be removed in the next version */
   useTestUsers?: boolean;
+  locationId?: string;
 };
 
 export type LucraClientOnMessage = {
@@ -86,6 +90,7 @@ export type LucraClientOnMessage = {
   deepLink: (data: LucraDeepLinkBody) => void;
   navigationEvent: (data: LucraNavigationEventBody) => void;
   claimReward: (data: LucraClaimRewardBody) => void;
+  loginSuccess: (data: LucraLoginSuccessBody) => void;
 };
 
 export type LucraClientSendMessage = {
@@ -101,6 +106,20 @@ export type LucraClientMessage = (body: {
   type: LucraClientMessageType;
   data: any;
 }) => void;
+
+export type LucraPage =
+  | "add-funds"
+  | "create-matchup"
+  | "home"
+  | "id-scan-complete"
+  | "kyc"
+  | "logout"
+  | "matchup-details"
+  | "profile"
+  | "search"
+  | "tournament-details"
+  | "transactions"
+  | "withdraw-funds";
 
 export type StateFull =
   | "Alaska"


### PR DESCRIPTION
- LucraClient constructor now accepts `locationId` to set the location without having to navigate to `home`
- LucraClient constructor has deprecated `useTestUsers` as its now no longer needed to log in with test users
- Calling `.open` on the LucraClient when it's already open will perform a `redirect` instead of incorrectly adding another iframe
- New `loginSuccess` callback that receives the user info. Wait for this callback to fire before sending any messages to LucraClient


Will publish to v0.16.0, have follow-up PRs for the web app and sdk sample app