### PR TITLE
Add hide, show, and moveTo methods to LucraClientBase

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -84,11 +84,13 @@ export class LucraClientBase extends EventTarget {
     path = "",
     params = new URLSearchParams(),
     deepLinkUrl,
+    hidden,
   }: {
     element: HTMLElement;
     path?: string;
     params?: URLSearchParams;
     deepLinkUrl?: string;
+    hidden?: boolean;
   }) {
     if (this.iframe) {
       return this._redirect(path, params, deepLinkUrl);
@@ -125,6 +127,9 @@ export class LucraClientBase extends EventTarget {
       iframe.allow =
         "geolocation *; web-share; accelerometer *; bluetooth *; gyroscope *; clipboard-write *; payment;";
       element.appendChild(iframe);
+      if (hidden) {
+        iframe.style.display = "none";
+      }
     } catch (e) {
       console.error("Error opening up LucraSports", e);
     }
@@ -194,35 +199,35 @@ export class LucraClientBase extends EventTarget {
     };
   }
 
-  open(element: HTMLElement, phoneNumber?: string): LucraNavigation {
+  open(element: HTMLElement, phoneNumber?: string, options?: { hidden?: boolean }): LucraNavigation {
     return {
       profile: () => {
         const params = addDefinedSearchParams({ phoneNumber });
-        return this._open({ element, path: "app/profile", params });
+        return this._open({ element, path: "app/profile", params, hidden: options?.hidden });
       },
       home: (locationId?: string) => {
         const params = addDefinedSearchParams({ locationId, phoneNumber });
-        return this._open({ element, path: "app/home", params });
+        return this._open({ element, path: "app/home", params, hidden: options?.hidden });
       },
       deposit: () => {
         const params = addDefinedSearchParams({ phoneNumber });
-        return this._open({ element, path: "app/add-funds", params });
+        return this._open({ element, path: "app/add-funds", params, hidden: options?.hidden });
       },
       withdraw: () => {
         const params = addDefinedSearchParams({ phoneNumber });
-        return this._open({ element, path: "app/withdraw-funds", params });
+        return this._open({ element, path: "app/withdraw-funds", params, hidden: options?.hidden });
       },
       createMatchup: (gameId?: string) => {
         const params = addDefinedSearchParams({ openGameId: gameId, phoneNumber });
-        return this._open({ element, path: "app/home", params });
+        return this._open({ element, path: "app/home", params, hidden: options?.hidden });
       },
       matchupDetails: (matchupId: string) => {
         const params = addDefinedSearchParams({ phoneNumber });
-        return this._open({ element, path: `app/matchups/${matchupId}`, params });
+        return this._open({ element, path: `app/matchups/${matchupId}`, params, hidden: options?.hidden });
       },
       tournamentDetails: (matchupId: string) => {
         const params = addDefinedSearchParams({ phoneNumber });
-        return this._open({ element, path: `app/tournaments/${matchupId}`, params });
+        return this._open({ element, path: `app/tournaments/${matchupId}`, params, hidden: options?.hidden });
       },
       deepLink: (url: string) => {
         if (this.urlOrigin === "" || new URL(url).origin !== this.urlOrigin) {
@@ -232,6 +237,7 @@ export class LucraClientBase extends EventTarget {
           element,
           deepLinkUrl: url,
           params: addDefinedSearchParams({ phoneNumber }),
+          hidden: options?.hidden,
         });
       },
     };
@@ -242,6 +248,27 @@ export class LucraClientBase extends EventTarget {
     this.controller = new AbortController();
     this.iframe?.remove();
     this.iframe = undefined;
+  }
+
+  moveTo(element: HTMLElement): LucraClientBase {
+    if (this.iframe) {
+      element.appendChild(this.iframe);
+    }
+    return this;
+  }
+
+  hide(): LucraClientBase {
+    if (this.iframe) {
+      this.iframe.style.display = "none";
+    }
+    return this;
+  }
+
+  show(): LucraClientBase {
+    if (this.iframe) {
+      this.iframe.style.display = "block";
+    }
+    return this;
   }
 
   protected _sendMessage(message: any) {

--- a/dist/base.d.ts
+++ b/dist/base.d.ts
@@ -27,8 +27,13 @@ export declare class LucraClientBase extends EventTarget {
     private _redirect;
     logout(): LucraClientBase;
     redirect(): LucraNavigation;
-    open(element: HTMLElement, phoneNumber?: string): LucraNavigation;
+    open(element: HTMLElement, phoneNumber?: string, options?: {
+        hidden?: boolean;
+    }): LucraNavigation;
     close(): void;
+    moveTo(element: HTMLElement): LucraClientBase;
+    hide(): LucraClientBase;
+    show(): LucraClientBase;
     protected _sendMessage(message: any): this;
     protected _matchupInviteUrlResponse(data: LucraDeepLinkResponse): void;
     sendMessage: LucraClientSendMessage;

--- a/dist/base.js
+++ b/dist/base.js
@@ -35,7 +35,7 @@ export class LucraClientBase extends EventTarget {
                 ? `http://localhost:3000`
                 : `https://${this.tenantId.toLowerCase()}.${this.env !== "production" ? `${this.env}.` : ""}lucrasports.com`;
     }
-    _open({ element, path = "", params = new URLSearchParams(), deepLinkUrl, }) {
+    _open({ element, path = "", params = new URLSearchParams(), deepLinkUrl, hidden, }) {
         if (this.iframe) {
             return this._redirect(path, params, deepLinkUrl);
         }
@@ -61,6 +61,9 @@ export class LucraClientBase extends EventTarget {
             iframe.allow =
                 "geolocation *; web-share; accelerometer *; bluetooth *; gyroscope *; clipboard-write *; payment;";
             element.appendChild(iframe);
+            if (hidden) {
+                iframe.style.display = "none";
+            }
         }
         catch (e) {
             console.error("Error opening up LucraSports", e);
@@ -118,35 +121,35 @@ export class LucraClientBase extends EventTarget {
             },
         };
     }
-    open(element, phoneNumber) {
+    open(element, phoneNumber, options) {
         return {
             profile: () => {
                 const params = addDefinedSearchParams({ phoneNumber });
-                return this._open({ element, path: "app/profile", params });
+                return this._open({ element, path: "app/profile", params, hidden: options?.hidden });
             },
             home: (locationId) => {
                 const params = addDefinedSearchParams({ locationId, phoneNumber });
-                return this._open({ element, path: "app/home", params });
+                return this._open({ element, path: "app/home", params, hidden: options?.hidden });
             },
             deposit: () => {
                 const params = addDefinedSearchParams({ phoneNumber });
-                return this._open({ element, path: "app/add-funds", params });
+                return this._open({ element, path: "app/add-funds", params, hidden: options?.hidden });
             },
             withdraw: () => {
                 const params = addDefinedSearchParams({ phoneNumber });
-                return this._open({ element, path: "app/withdraw-funds", params });
+                return this._open({ element, path: "app/withdraw-funds", params, hidden: options?.hidden });
             },
             createMatchup: (gameId) => {
                 const params = addDefinedSearchParams({ openGameId: gameId, phoneNumber });
-                return this._open({ element, path: "app/home", params });
+                return this._open({ element, path: "app/home", params, hidden: options?.hidden });
             },
             matchupDetails: (matchupId) => {
                 const params = addDefinedSearchParams({ phoneNumber });
-                return this._open({ element, path: `app/matchups/${matchupId}`, params });
+                return this._open({ element, path: `app/matchups/${matchupId}`, params, hidden: options?.hidden });
             },
             tournamentDetails: (matchupId) => {
                 const params = addDefinedSearchParams({ phoneNumber });
-                return this._open({ element, path: `app/tournaments/${matchupId}`, params });
+                return this._open({ element, path: `app/tournaments/${matchupId}`, params, hidden: options?.hidden });
             },
             deepLink: (url) => {
                 if (this.urlOrigin === "" || new URL(url).origin !== this.urlOrigin) {
@@ -156,6 +159,7 @@ export class LucraClientBase extends EventTarget {
                     element,
                     deepLinkUrl: url,
                     params: addDefinedSearchParams({ phoneNumber }),
+                    hidden: options?.hidden,
                 });
             },
         };
@@ -165,6 +169,24 @@ export class LucraClientBase extends EventTarget {
         this.controller = new AbortController();
         this.iframe?.remove();
         this.iframe = undefined;
+    }
+    moveTo(element) {
+        if (this.iframe) {
+            element.appendChild(this.iframe);
+        }
+        return this;
+    }
+    hide() {
+        if (this.iframe) {
+            this.iframe.style.display = "none";
+        }
+        return this;
+    }
+    show() {
+        if (this.iframe) {
+            this.iframe.style.display = "block";
+        }
+        return this;
     }
     _sendMessage(message) {
         try {

--- a/docs/1.3_lucraflows.md
+++ b/docs/1.3_lucraflows.md
@@ -20,6 +20,35 @@ client.open(element, phoneNumber?)
 
 Where phone number (if valid) will automatically send the SMS verification code, skipping the step where the user must enter phone number manually.
 
+### Visibility and Placement
+
+Hide the Lucra experience without removing it from the DOM:
+
+```typescript
+const client = LucraClient.getInstance();
+client.hide();
+```
+
+Restore it:
+
+```typescript
+client.show();
+```
+
+Move the iframe to a different container element (does not reload):
+
+```typescript
+client.moveTo(otherElement);
+```
+
+Start the experience hidden from the very first render:
+
+```typescript
+client.open(element, phoneNumber, { hidden: true }).home();
+// later...
+client.show();
+```
+
 ### Redirect Lucra
 
 ```typescript

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [v1.1.0]
+
+### Added
+
+- `hide()` method to make the Lucra iframe invisible without removing it from the DOM
+- `show()` method to restore the Lucra iframe to visible
+- `moveTo(element)` method to move the Lucra iframe to a different parent element without reloading
+- `open()` now accepts an optional third argument `options?: { hidden?: boolean }` to start the experience in a hidden state
+
 ## [v1.0.0]
 
 ### Added


### PR DESCRIPTION
  - hide() sets display:none on the iframe without removing it from the DOM
  - show() restores the iframe to visible
  - moveTo(element) moves the iframe to a new parent without reloading
  - open() accepts an optional third argument { hidden: boolean } to start the experience invisible from the first render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Control Lucra experience visibility with new `hide()` and `show()` methods
  * Relocate the experience to different page containers with `moveTo()`
  * Start experiences in a hidden state using the `open()` method's new options

* **Documentation**
  * Added guidance on visibility and placement controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->