### PR TITLE
Support for opening demographic collection form in a dialog

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -54,6 +54,7 @@ type LucraNavigation = {
   tournamentDetails: (matchupId: string) => LucraClientBase;
   deepLink: (url: string) => LucraClientBase;
   kyc: () => LucraClientBase;
+  demographic: () => LucraClientBase;
 };
 
 type LucraOpenNavigation = LucraNavigation & {
@@ -74,6 +75,7 @@ type LucraDialogNavigation = {
   tournamentDetails: (matchupId: string) => LucraDialog;
   deepLink: (url: string) => LucraDialog;
   kyc: () => LucraDialog;
+  demographic: () => LucraDialog;
 };
 
 type LucraPopupNavigation = {
@@ -432,7 +434,8 @@ export class LucraClientBase extends EventTarget {
         }
         return this._redirect("", undefined, url);
       },
-      kyc: () => this._redirect("app/kyc")
+      kyc: () => this._redirect("app/kyc"),
+      demographic: () => this._redirect("app/demographicform")
     };
   }
 
@@ -455,7 +458,8 @@ export class LucraClientBase extends EventTarget {
       tournamentDetails: (matchupId: string) =>
         present(() => nav.tournamentDetails(matchupId)),
       deepLink: (url: string) => present(() => nav.deepLink(url)),
-      kyc: () => present(() => nav.kyc())
+      kyc: () => present(() => nav.kyc()),
+      demographic: () => present(() => nav.demographic())
     };
   }
 
@@ -591,6 +595,11 @@ export class LucraClientBase extends EventTarget {
       kyc: () => {
         const params = addDefinedSearchParams({ phoneNumber })
         return this._open({ element, path: "app/kyc", params, hidden: options?.hidden })
+      },
+
+      demographic: () => {
+        const params = addDefinedSearchParams({ phoneNumber })
+        return this._open({ element, path: "app/demographicform", params, hidden: options?.hidden })
       }
     };
   }

--- a/dist/base.d.ts
+++ b/dist/base.d.ts
@@ -10,6 +10,7 @@ type LucraNavigation = {
     tournamentDetails: (matchupId: string) => LucraClientBase;
     deepLink: (url: string) => LucraClientBase;
     kyc: () => LucraClientBase;
+    demographic: () => LucraClientBase;
 };
 type LucraOpenNavigation = LucraNavigation & {
     minigamesTrigger: (input: LucraMinigamesTriggerInput) => Promise<LucraStartMinigamesSessionResponse>;
@@ -26,6 +27,7 @@ type LucraDialogNavigation = {
     tournamentDetails: (matchupId: string) => LucraDialog;
     deepLink: (url: string) => LucraDialog;
     kyc: () => LucraDialog;
+    demographic: () => LucraDialog;
 };
 type LucraPopupNavigation = {
     deposit: () => LucraPopup;

--- a/dist/base.js
+++ b/dist/base.js
@@ -278,7 +278,8 @@ export class LucraClientBase extends EventTarget {
                 }
                 return this._redirect("", undefined, url);
             },
-            kyc: () => this._redirect("app/kyc")
+            kyc: () => this._redirect("app/kyc"),
+            demographic: () => this._redirect("app/demographicform")
         };
     }
     // Opens any route as a dialog. Reuses redirect()'s in-place navigation (no
@@ -296,7 +297,8 @@ export class LucraClientBase extends EventTarget {
             matchupDetails: (matchupId) => present(() => nav.matchupDetails(matchupId)),
             tournamentDetails: (matchupId) => present(() => nav.tournamentDetails(matchupId)),
             deepLink: (url) => present(() => nav.deepLink(url)),
-            kyc: () => present(() => nav.kyc())
+            kyc: () => present(() => nav.kyc()),
+            demographic: () => present(() => nav.demographic())
         };
     }
     // Presents the iframe's host as a dialog: shows the iframe, enables the in-app
@@ -419,6 +421,10 @@ export class LucraClientBase extends EventTarget {
             kyc: () => {
                 const params = addDefinedSearchParams({ phoneNumber });
                 return this._open({ element, path: "app/kyc", params, hidden: options?.hidden });
+            },
+            demographic: () => {
+                const params = addDefinedSearchParams({ phoneNumber });
+                return this._open({ element, path: "app/demographicform", params, hidden: options?.hidden });
             }
         };
     }

--- a/dist/types/types.d.ts
+++ b/dist/types/types.d.ts
@@ -5,6 +5,7 @@ export declare enum LucraClientMessageType {
     claimReward = "claimReward",
     convertToCredit = "convertToCredit",
     deepLink = "deepLink",
+    demographicComplete = "demographicComplete",
     exitLucra = "exitLucra",
     kycComplete = "kycComplete",
     loginSuccess = "loginSuccess",
@@ -135,6 +136,7 @@ export type LucraEventMap = {
     loginSuccess: LucraLoginSuccessBody;
     exitLucra: void;
     kycComplete: void;
+    demographicComplete: void;
     initialized: LucraInitializedBody;
 };
 export type LucraClientSendMessage = {
@@ -149,7 +151,7 @@ export type LucraClientMessage = (body: {
     type: LucraClientMessageType;
     data: any;
 }) => void;
-export type LucraPage = "add-funds" | "create-matchup" | "home" | "id-scan-complete" | "kyc" | "logout" | "matchup-details" | "profile" | "search" | "tournament-details" | "transactions" | "withdraw-funds";
+export type LucraPage = "add-funds" | "create-matchup" | "demographicform" | "home" | "id-scan-complete" | "kyc" | "logout" | "matchup-details" | "profile" | "search" | "tournament-details" | "transactions" | "withdraw-funds";
 export type StateFull = "Alaska" | "Alabama" | "Arkansas" | "Arizona" | "California" | "Colorado" | "Connecticut" | "District of Columbia" | "Delaware" | "Florida" | "Georgia" | "Hawaii" | "Iowa" | "Idaho" | "Illinois" | "Indiana" | "Kansas" | "Kentucky" | "Louisiana" | "Massachusetts" | "Maryland" | "Maine" | "Michigan" | "Minnesota" | "Missouri" | "Mississippi" | "Montana" | "North Carolina" | "North Dakota" | "Nebraska" | "New Hampshire" | "New Jersey" | "New Mexico" | "Nevada" | "New York" | "Ohio" | "Oklahoma" | "Oregon" | "Pennsylvania" | "Rhode Island" | "South Carolina" | "South Dakota" | "Tennessee" | "Texas" | "Utah" | "Virginia" | "Vermont" | "Washington" | "Wisconsin" | "West Virginia" | "Wyoming";
 export type StateCode = "AK" | "AL" | "AR" | "AZ" | "CA" | "CO" | "CT" | "DC" | "DE" | "FL" | "GA" | "HI" | "IA" | "ID" | "IL" | "IN" | "KS" | "KY" | "LA" | "MA" | "MD" | "ME" | "MI" | "MN" | "MO" | "MS" | "MT" | "NC" | "ND" | "NE" | "NH" | "NJ" | "NM" | "NV" | "NY" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VA" | "VT" | "WA" | "WI" | "WV" | "WY";
 declare enum account_status_types_enum {

--- a/dist/types/types.js
+++ b/dist/types/types.js
@@ -5,6 +5,7 @@ export var LucraClientMessageType;
     LucraClientMessageType["claimReward"] = "claimReward";
     LucraClientMessageType["convertToCredit"] = "convertToCredit";
     LucraClientMessageType["deepLink"] = "deepLink";
+    LucraClientMessageType["demographicComplete"] = "demographicComplete";
     LucraClientMessageType["exitLucra"] = "exitLucra";
     LucraClientMessageType["kycComplete"] = "kycComplete";
     LucraClientMessageType["loginSuccess"] = "loginSuccess";

--- a/docs/1.3_lucraflows.md
+++ b/docs/1.3_lucraflows.md
@@ -18,6 +18,7 @@ client.open(element, phoneNumber?)
   .tournamentDetails(matchupId)
   .deepLink(url)
   .kyc()
+  .demographic()
 ```
 
 Where phone number (if valid) will automatically send the SMS verification code, skipping the step where the user must enter phone number manually.
@@ -69,6 +70,7 @@ client.redirect()
   .tournamentDetails(matchupId)
   .deepLink(url)
   .kyc()
+  .demographic()
 ```
 
 ### Dialogs
@@ -91,6 +93,7 @@ client.dialog()
   .tournamentDetails(matchupId)
   .deepLink(url)
   .kyc()
+  .demographic()
 ```
 
 When KYC is opened as a dialog, Lucra does not navigate away once the user finishes — it emits a [`kycComplete`](1.6_lucra_event_listener.md) event so the embedding app can close the dialog:
@@ -98,6 +101,13 @@ When KYC is opened as a dialog, Lucra does not navigate away once the user finis
 ```typescript
 const dialog = client.dialog().kyc();
 client.on('kycComplete', () => dialog.close());
+```
+
+Demographic collection works the same way — opened as a dialog it emits a [`demographicComplete`](1.6_lucra_event_listener.md) event so the embedding app can close the dialog:
+
+```typescript
+const dialog = client.dialog().demographic();
+client.on('demographicComplete', () => dialog.close());
 ```
 
 The element the iframe currently lives in (the one passed to `open()` / `moveTo()`) is styled as a fullscreen overlay while open, and restored on close.

--- a/docs/1.6_lucra_event_listener.md
+++ b/docs/1.6_lucra_event_listener.md
@@ -46,6 +46,7 @@ client.off('userInfo', handleUserInfo);
 | `claimReward` | `{ reward: LucraReward }` | User is redeeming a Free To Play reward |
 | `exitLucra` | `void` | User attempted to exit Lucra |
 | `kycComplete` | `void` | User finished the KYC flow |
+| `demographicComplete` | `void` | User finished the demographic collection flow |
 | `initialized` | `{ success: boolean }` | Lucra iframe finished initializing |
 
 `kycComplete` fires when the user finishes the KYC flow opened via `kyc()` (see [Lucra Flows](1.3_lucraflows.md)). Lucra does not navigate away on completion, so the embedding app decides what happens next — typically closing the dialog it opened KYC in:
@@ -54,6 +55,16 @@ client.off('userInfo', handleUserInfo);
 const dialog = client.dialog().kyc();
 
 client.on('kycComplete', () => {
+  dialog.close();
+});
+```
+
+`demographicComplete` fires when the user finishes the demographic collection flow opened via `demographic()` (see [Lucra Flows](1.3_lucraflows.md)). As with KYC, Lucra does not navigate away on completion, so the embedding app closes the dialog it opened:
+
+```typescript
+const dialog = client.dialog().demographic();
+
+client.on('demographicComplete', () => {
   dialog.close();
 });
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [v1.8.0]
+
+### Added
+
+- `demographic()` navigation on `open()`, `redirect()`, and `dialog()` that opens the `app/demographicform` demographic-collection flow: `client.open(element).demographic()`, `client.dialog().demographic()`.
+- `demographicComplete` event (payload `void`) fired when the user finishes the demographic collection flow. Lucra does not navigate away on completion, so the embedding app reacts — typically by closing the dialog it opened the flow in: `client.on('demographicComplete', () => dialog.close())`. See [Lucra Event Listener](1.6_lucra_event_listener.md).
+
 ## [v1.7.0]
 
 ### Added

--- a/types/types.ts
+++ b/types/types.ts
@@ -12,6 +12,7 @@ export enum LucraClientMessageType {
   claimReward = "claimReward",
   convertToCredit = "convertToCredit",
   deepLink = "deepLink",
+  demographicComplete = "demographicComplete",
   exitLucra = "exitLucra",
   kycComplete = "kycComplete",
   loginSuccess = "loginSuccess",
@@ -137,6 +138,7 @@ export type LucraEventMap = {
   loginSuccess: LucraLoginSuccessBody;
   exitLucra: void;
   kycComplete: void;
+  demographicComplete: void;
   initialized: LucraInitializedBody;
 };
 
@@ -157,6 +159,7 @@ export type LucraClientMessage = (body: {
 export type LucraPage =
   | "add-funds"
   | "create-matchup"
+  | "demographicform"
   | "home"
   | "id-scan-complete"
   | "kyc"


### PR DESCRIPTION
Allow for opening up a demographic collection form when demographicMissing is thrown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new demographic flow available from open, redirect, and dialog navigation.
  * Added support for opening the demographic form directly in an embedded dialog or iframe.
  * Introduced a new completion event so apps can respond when the demographic flow finishes.

* **Documentation**
  * Updated usage guides and changelog examples to show the new demographic route and completion event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->