### PR TITLE
Support for fetching tournaments prior to auth

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -173,6 +173,11 @@ export class LucraClientBase extends EventTarget {
         }
         throw reason;
       });
+    // Mark the rejection handled so a pre-auth consumer who never awaits
+    // `ready` (e.g. one that only fetches tournaments while logged out) does
+    // not trigger an unhandled rejection. `get ready()` still returns
+    // `promise`, so callers that do await it still observe the rejection.
+    promise.catch(() => {});
     return promise;
   }
 
@@ -721,8 +726,19 @@ export class LucraClientBase extends EventTarget {
   api = {
     achievements: (): Promise<LucraAchievementsResponse> =>
       this._achievementsRequest.send(),
-    tournaments: (): Promise<LucraTournamentsResponse> =>
-      this._tournamentsRequest.send(),
+    // Fetching all tournaments is allowed before auth, so it only waits for the
+    // embedded app to be initialized (not `ready`, which also asserts login).
+    // Awaiting init also keeps the request from racing initialization -- it is
+    // sent once the iframe is ready to receive it. The detail and leaderboard
+    // reads require auth, so callers reach them after `ready` (init guaranteed)
+    // and they send immediately.
+    // Note: if `close()` runs while this is still awaiting a not-yet-resolved
+    // init, the captured promise never settles and this call stays pending --
+    // an accepted edge given the narrow window.
+    tournaments: async (): Promise<LucraTournamentsResponse> => {
+      await this._initializedPromise;
+      return this._tournamentsRequest.send();
+    },
     tournament: (matchupId: string): Promise<LucraTournamentResponse> =>
       this._tournamentRequest.send({ matchupId }),
     tournamentLeaderboard: (

--- a/dist/base.js
+++ b/dist/base.js
@@ -84,6 +84,11 @@ export class LucraClientBase extends EventTarget {
             }
             throw reason;
         });
+        // Mark the rejection handled so a pre-auth consumer who never awaits
+        // `ready` (e.g. one that only fetches tournaments while logged out) does
+        // not trigger an unhandled rejection. `get ready()` still returns
+        // `promise`, so callers that do await it still observe the rejection.
+        promise.catch(() => { });
         return promise;
     }
     async _assertLoggedIn() {
@@ -525,7 +530,19 @@ export class LucraClientBase extends EventTarget {
     }
     api = {
         achievements: () => this._achievementsRequest.send(),
-        tournaments: () => this._tournamentsRequest.send(),
+        // Fetching all tournaments is allowed before auth, so it only waits for the
+        // embedded app to be initialized (not `ready`, which also asserts login).
+        // Awaiting init also keeps the request from racing initialization -- it is
+        // sent once the iframe is ready to receive it. The detail and leaderboard
+        // reads require auth, so callers reach them after `ready` (init guaranteed)
+        // and they send immediately.
+        // Note: if `close()` runs while this is still awaiting a not-yet-resolved
+        // init, the captured promise never settles and this call stays pending --
+        // an accepted edge given the narrow window.
+        tournaments: async () => {
+            await this._initializedPromise;
+            return this._tournamentsRequest.send();
+        },
         tournament: (matchupId) => this._tournamentRequest.send({ matchupId }),
         tournamentLeaderboard: (matchupId, pagination) => this._tournamentLeaderboardRequest.send({
             matchupId,

--- a/docs/1.6_lucra_event_listener.md
+++ b/docs/1.6_lucra_event_listener.md
@@ -93,7 +93,7 @@ The `api` object exposes Promise-based requests to Lucra.
 const { achievements } = await client.api.achievements();
 ```
 
-`api.tournaments()` resolves with the list of recommended pool tournaments.
+`api.tournaments()` resolves with the list of recommended pool tournaments. It can be called before the user is logged in: it waits internally for the iframe to initialize (it does not require `await client.ready`) and does not need a logged-in user, so the list can be fetched ahead of auth. The other reads (`tournament`, `tournamentLeaderboard`, `joinTournament`) require a logged-in user.
 
 ```typescript
 const { tournaments } = await client.api.tournaments();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v1.9.0]
+
+### Changed
+
+- `api.tournaments()` can now be called before the user is logged in. It awaits iframe initialization internally (instead of requiring `await client.ready`, which also asserts login) and resolves with the tournament list for logged-out users. The detail and leaderboard reads (`api.tournament()`, `api.tournamentLeaderboard()`) still require a logged-in user. See [Async API](1.6_lucra_event_listener.md#async-api).
+
 ## [v1.8.0]
 
 ### Added

--- a/v1.test.ts
+++ b/v1.test.ts
@@ -15,6 +15,17 @@ afterEach(() => {
   LucraClient.destroy();
 });
 
+// The tournament read methods await `_initializedPromise` before sending so they
+// work before auth. Resolve it directly to let those reads proceed without
+// triggering the login chain.
+function markInitialized(client: LucraClient) {
+  (client as any)._initializedPromise = Promise.resolve();
+}
+
+// Yield a macrotask so the awaited `_initializedPromise` settles and the
+// init-gated send fires.
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 describe("LucraClient.initialize", () => {
   it("returns an instance on first call", () => {
     const client = LucraClient.initialize(baseConfig);
@@ -140,12 +151,14 @@ describe("LucraClient.on / off", () => {
 });
 
 describe("LucraClient.api.tournaments", () => {
-  it("posts a tournamentsRequest message to the iframe", () => {
+  it("posts a tournamentsRequest message to the iframe", async () => {
     const client = LucraClient.initialize(baseConfig);
     const sendMessage = mock(() => {});
     (client as any)._sendMessage = sendMessage;
+    markInitialized(client);
 
     client.api.tournaments().catch(() => {});
+    await flush();
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith({
@@ -156,7 +169,9 @@ describe("LucraClient.api.tournaments", () => {
 
   it("resolves with the data when a tournamentsResponse message arrives", async () => {
     const client = LucraClient.initialize(baseConfig);
+    markInitialized(client);
     const promise = client.api.tournaments();
+    await flush();
     const data = {
       tournaments: [
         {
@@ -193,10 +208,48 @@ describe("LucraClient.api.tournaments", () => {
 
   it("rejects an in-flight request when a new request is made", async () => {
     const client = LucraClient.initialize(baseConfig);
+    markInitialized(client);
     const first = client.api.tournaments();
     client.api.tournaments().catch(() => {});
 
     await expect(first).rejects.toBe("Cancelled by new tournaments request");
+  });
+
+  it("fetches tournaments without a logged-in user once the iframe is initialized", async () => {
+    const client = LucraClient.initialize(baseConfig);
+    // A pre-auth consumer never awaits `ready`; the internal guard in
+    // `_createReadyPromise` keeps its logged-out rejection from going unhandled.
+    const promise = client.api.tournaments();
+
+    // The embedded app finishes initializing, but the user is not logged in.
+    await (client as any)._eventListener({
+      origin: "https://test-tenant.sandbox.lucrasports.com",
+      data: { type: "initialized", data: { success: true } },
+    });
+    await (client as any)._eventListener({
+      origin: "https://test-tenant.sandbox.lucrasports.com",
+      data: { type: "isLoggedInResponse", data: { isLoggedIn: false } },
+    });
+
+    const data = { tournaments: [] };
+    await (client as any)._eventListener({
+      origin: "https://test-tenant.sandbox.lucrasports.com",
+      data: { type: "tournamentsResponse", data },
+    });
+
+    expect(await promise).toEqual(data);
+  });
+
+  it("rejects when the iframe fails to initialize", async () => {
+    const client = LucraClient.initialize(baseConfig);
+    const promise = client.api.tournaments();
+
+    await (client as any)._eventListener({
+      origin: "https://test-tenant.sandbox.lucrasports.com",
+      data: { type: "initialized", data: { success: false } },
+    });
+
+    await expect(promise).rejects.toEqual({ success: false });
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `api.tournaments()` now works before login and returns recommended pool tournaments after initialization completes.
* **Bug Fixes**
  * Prevented an unhandled promise rejection when `ready` is never awaited.
  * Fixed tournament requests from racing iframe startup, improving reliability on first load.
* **Documentation**
  * Updated usage notes and changelog to clarify which tournament APIs require a signed-in user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->